### PR TITLE
Fix deposit arguments for coins

### DIFF
--- a/src/transactions/balance_manager.rs
+++ b/src/transactions/balance_manager.rs
@@ -128,7 +128,7 @@ impl BalanceManagerContract {
 
         let arguments = vec![
             ptb.obj(self.client.share_object_mutable(manager_id).await?)?,
-            ptb.pure(self.client.coin_object(deposit_coin).await?)?,
+            ptb.obj(self.client.coin_object(deposit_coin).await?)?,
         ];
 
         ptb.programmable_move_call(
@@ -436,7 +436,7 @@ impl BalanceManagerContract {
         let arguments = vec![
             ptb.obj(self.client.share_object_mutable(manager_id).await?)?,
             ptb.obj(self.client.share_object(deposit_cap_id).await?)?,
-            ptb.pure(self.client.coin_object(deposit_coin).await?)?,
+            ptb.obj(self.client.coin_object(deposit_coin).await?)?,
         ];
 
         ptb.programmable_move_call(


### PR DESCRIPTION
gm @lispking 

The coin object is passed as pure instead of object, so deposits were broken.