### PR TITLE
Fixes placing market orders and placing/canceling limit orders

### DIFF
--- a/src/transactions/balance_manager.rs
+++ b/src/transactions/balance_manager.rs
@@ -283,7 +283,7 @@ impl BalanceManagerContract {
         manager_id: &ObjectID,
     ) -> anyhow::Result<Argument> {
         let package_id = ObjectID::from_hex_literal(self.config.deepbook_package_id())?;
-        let arguments = vec![ptb.obj(self.client.share_object(*manager_id).await?)?];
+        let arguments = vec![ptb.obj(self.client.share_object_mutable(*manager_id).await?)?];
         Ok(ptb.programmable_move_call(
             package_id,
             Identifier::new("balance_manager")?,
@@ -306,7 +306,7 @@ impl BalanceManagerContract {
     ) -> anyhow::Result<Argument> {
         let package_id = ObjectID::from_hex_literal(self.config.deepbook_package_id())?;
         let arguments = vec![
-            ptb.obj(self.client.share_object(*manager_id).await?)?,
+            ptb.obj(self.client.share_object_mutable(*manager_id).await?)?,
             ptb.obj(self.client.share_object(*trade_cap_id).await?)?,
         ];
         Ok(ptb.programmable_move_call(

--- a/src/transactions/deepbook.rs
+++ b/src/transactions/deepbook.rs
@@ -176,7 +176,7 @@ impl DeepBookContract {
         ptb: &mut ProgrammableTransactionBuilder,
         pool_key: &str,
         balance_manager_key: &str,
-        order_id: &str,
+        order_id: u128,
         new_quantity: f64,
     ) -> anyhow::Result<Argument> {
         let pool = self.config.get_pool(pool_key)?;
@@ -192,14 +192,13 @@ impl DeepBookContract {
 
         let pool_id = ObjectID::from_hex_literal(&pool.address)?;
         let balance_manager_id = ObjectID::from_hex_literal(&balance_manager.address)?;
-        let order_id = ObjectID::from_hex_literal(order_id)?;
 
         let base_coin_tag = TypeTag::from_str(&base_coin.type_name)?;
         let quote_coin_tag = TypeTag::from_str(&quote_coin.type_name)?;
 
         let arguments = vec![
-            ptb.obj(self.client.share_object(pool_id).await?)?,
-            ptb.obj(self.client.share_object(balance_manager_id).await?)?,
+            ptb.obj(self.client.share_object_mutable(pool_id).await?)?,
+            ptb.obj(self.client.share_object_mutable(balance_manager_id).await?)?,
             trade_proof,
             ptb.pure(order_id)?,
             ptb.pure(input_quantity)?,

--- a/src/transactions/deepbook.rs
+++ b/src/transactions/deepbook.rs
@@ -2,8 +2,10 @@ use std::str::FromStr;
 use sui_sdk::{
     rpc_types::Coin,
     types::{
-        base_types::{ObjectID, SuiAddress}, programmable_transaction_builder::ProgrammableTransactionBuilder,
-        transaction::Argument, Identifier, TypeTag, SUI_CLOCK_OBJECT_ID,
+        base_types::{ObjectID, SuiAddress},
+        programmable_transaction_builder::ProgrammableTransactionBuilder,
+        transaction::Argument,
+        Identifier, TypeTag, SUI_CLOCK_OBJECT_ID,
     },
     SuiClient,
 };
@@ -84,8 +86,8 @@ impl DeepBookContract {
         let quote_coin_tag = TypeTag::from_str(&quote_coin.type_name)?;
 
         let arguments = vec![
-            ptb.obj(self.client.share_object(pool_id).await?)?,
-            ptb.obj(self.client.share_object(balance_manager_id).await?)?,
+            ptb.obj(self.client.share_object_mutable(pool_id).await?)?,
+            ptb.obj(self.client.share_object_mutable(balance_manager_id).await?)?,
             trade_proof,
             ptb.pure(params.client_order_id)?,
             ptb.pure(order_type as u8)?,
@@ -225,7 +227,7 @@ impl DeepBookContract {
         ptb: &mut ProgrammableTransactionBuilder,
         pool_key: &str,
         balance_manager_key: &str,
-        order_id: &str,
+        order_id: u128,
     ) -> anyhow::Result<Argument> {
         let pool = self.config.get_pool(pool_key)?;
         let balance_manager = self.config.get_balance_manager(balance_manager_key)?;
@@ -239,14 +241,13 @@ impl DeepBookContract {
 
         let pool_id = ObjectID::from_hex_literal(&pool.address)?;
         let balance_manager_id = ObjectID::from_hex_literal(&balance_manager.address)?;
-        let order_id = ObjectID::from_hex_literal(order_id)?;
 
         let base_coin_tag = TypeTag::from_str(&base_coin.type_name)?;
         let quote_coin_tag = TypeTag::from_str(&quote_coin.type_name)?;
 
         let arguments = vec![
-            ptb.obj(self.client.share_object(pool_id).await?)?,
-            ptb.obj(self.client.share_object(balance_manager_id).await?)?,
+            ptb.obj(self.client.share_object_mutable(pool_id).await?)?,
+            ptb.obj(self.client.share_object_mutable(balance_manager_id).await?)?,
             trade_proof,
             ptb.pure(order_id)?,
             ptb.obj(self.client.share_object(SUI_CLOCK_OBJECT_ID).await?)?,
@@ -290,8 +291,8 @@ impl DeepBookContract {
         let quote_coin_tag = TypeTag::from_str(&quote_coin.type_name)?;
 
         let arguments = vec![
-            ptb.obj(self.client.share_object(pool_id).await?)?,
-            ptb.obj(self.client.share_object(balance_manager_id).await?)?,
+            ptb.obj(self.client.share_object_mutable(pool_id).await?)?,
+            ptb.obj(self.client.share_object_mutable(balance_manager_id).await?)?,
             trade_proof,
             ptb.obj(self.client.share_object(SUI_CLOCK_OBJECT_ID).await?)?,
         ];

--- a/src/transactions/deepbook.rs
+++ b/src/transactions/deepbook.rs
@@ -143,8 +143,8 @@ impl DeepBookContract {
         let quote_coin_tag = TypeTag::from_str(&quote_coin.type_name)?;
 
         let arguments = vec![
-            ptb.obj(self.client.share_object(pool_id).await?)?,
-            ptb.obj(self.client.share_object(balance_manager_id).await?)?,
+            ptb.obj(self.client.share_object_mutable(pool_id).await?)?,
+            ptb.obj(self.client.share_object_mutable(balance_manager_id).await?)?,
             trade_proof,
             ptb.pure(params.client_order_id)?,
             ptb.pure(self_matching_option as u8)?,

--- a/src/utils/config.rs
+++ b/src/utils/config.rs
@@ -83,7 +83,6 @@ impl DeepBookConfig {
     }
 
     pub fn get_balance_manager(&self, manager_key: &str) -> anyhow::Result<&BalanceManager> {
-        println!("Balance managers: {:?}", self.balance_managers);
         self.balance_managers
             .get(manager_key)
             .ok_or(anyhow::anyhow!(

--- a/src/utils/types.rs
+++ b/src/utils/types.rs
@@ -54,7 +54,7 @@ pub enum SelfMatchingOptions {
 pub struct PlaceLimitOrderParams {
     pub pool_key: String,
     pub balance_manager_key: String,
-    pub client_order_id: String,
+    pub client_order_id: u64,
     pub price: f64,
     pub quantity: f64,
     pub is_bid: bool,

--- a/src/utils/types.rs
+++ b/src/utils/types.rs
@@ -69,7 +69,7 @@ pub struct PlaceLimitOrderParams {
 pub struct PlaceMarketOrderParams {
     pub pool_key: String,
     pub balance_manager_key: String,
-    pub client_order_id: String,
+    pub client_order_id: u64,
     pub quantity: f64,
     pub is_bid: bool,
     pub self_matching_option: Option<SelfMatchingOptions>,


### PR DESCRIPTION
Pools and balance managers are mutable shared objects.
Order IDs are `u128`.
Client order IDs are `u64`.